### PR TITLE
Performance improvements

### DIFF
--- a/src/forces.jl
+++ b/src/forces.jl
@@ -82,6 +82,8 @@ function force! end
     fdr = f * dr
     forces[i] -= fdr
     forces[j] += fdr
+
+    return nothing
 end
 
 @fastmath @inbounds function force!(forces,

--- a/src/types.jl
+++ b/src/types.jl
@@ -112,9 +112,9 @@ default values.
 - `n_steps_made::Vector{Int}=[]`: the number of steps already made during the
     simulation. This is a `Vector` to allow the `struct` to be immutable.
 """
-struct Simulation{T, U}
+struct Simulation{A, T, U}
     simulator::Simulator
-    atoms::Vector{<:Any}
+    atoms::Vector{A}
     specific_inter_lists::Dict{String, Vector{<:SpecificInteraction}}
     general_inters::Dict{String, <:GeneralInteraction}
     coords::U
@@ -144,7 +144,7 @@ function Simulation(;
                     timestep,
                     n_steps,
                     n_steps_made=[0])
-    return Simulation{typeof(timestep), typeof(coords)}(simulator, atoms,
+    return Simulation{eltype(atoms), typeof(timestep), typeof(coords)}(simulator, atoms,
                 specific_inter_lists, general_inters, coords, velocities,
                 temperature, box_size, neighbour_finder, thermostat, loggers,
                 timestep, n_steps, n_steps_made)


### PR DESCRIPTION
Hi!
I noticed that there some performance improvements that can be made. For example due to `atoms::Vector{<:Any}` a lot of dynamic dispatch was occurring inside force calculations. Adding another type parameter solved the problem and provided a ~40x speedup for Lenard-Jones interactions. I think further improvements can be made.
